### PR TITLE
Added support for thread/pipe idiom

### DIFF
--- a/doc/examples/threads/CMakeLists.txt
+++ b/doc/examples/threads/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(aziomq_threads main.cpp)
+target_link_libraries(aziomq_threads ${Boost_LIBRARIES}
+                                     ${ZeroMQ_LIBRARIES}
+                                     aziomq)
+

--- a/doc/examples/threads/main.cpp
+++ b/doc/examples/threads/main.cpp
@@ -1,0 +1,76 @@
+#include <aziomq/socket.hpp>
+#include <aziomq/thread.hpp>
+#include <boost/asio.hpp>
+
+#include <array>
+#include <string>
+#include <iostream>
+
+namespace asio = boost::asio;
+
+struct ping_handler {
+    asio::io_service & ios_;
+    aziomq::socket & s_;
+
+    using buffer_type = std::array<char, 1024>;
+    buffer_type & buf_;
+
+    ping_handler(asio::io_service & ios, aziomq::socket & s, buffer_type & buf)
+        : ios_(ios)
+        , s_(s)
+        , buf_(buf)
+    { }
+
+    void operator()(boost::system::error_code const& ec, size_t) {
+        if (ec) {
+            std::cout << "ping_handler error " << ec << std::endl;
+            return;
+        }
+
+        std::string req(buf_.data());
+        if (req != "PING!") {
+            s_.send(asio::buffer("BYE!"));
+            ios_.stop();
+            return;
+        }
+        s_.send(asio::buffer("PONG!"));
+        async_receive();
+    }
+
+    void async_receive() {
+        std::fill(std::begin(buf_), std::end(buf_), 0);
+        s_.async_receive(asio::buffer(buf_), *this);
+    }
+};
+
+int main(int argc, char** argv) {
+    asio::io_service ios;
+
+    auto server = aziomq::thread::fork(ios, [](aziomq::socket client, std::string howdy) {
+        client.send(asio::buffer(howdy));
+
+        auto& ios = client.get_io_service();
+        ping_handler::buffer_type buf;
+        ping_handler handler(ios, client, buf);
+        handler.async_receive();
+
+        ios.run();
+        std::cout << "Server thread exiting" << std::endl;
+    },
+    "HOWDY");
+
+    ping_handler::buffer_type buf;
+    auto bytes_transferred = server.receive(asio::buffer(buf));
+    std::cout << "Server says - " << std::string(buf.data(), bytes_transferred) << std::endl;
+
+    auto ping_for = 10;
+    for (int i = 0; i <= ping_for; i++) {
+        if (i == ping_for)
+            server.send(asio::buffer("HASTA LA VISTA, BABY!"));
+        else
+            server.send(asio::buffer("PING!"));
+
+        bytes_transferred = server.receive(asio::buffer(buf));
+        std::cout << "Server says - " << std::string(buf.data(), bytes_transferred) << std::endl;
+    }
+}

--- a/src/aziomq/thread.hpp
+++ b/src/aziomq/thread.hpp
@@ -1,0 +1,261 @@
+/*
+    Copyright (c) 2013-2014 Contributors as noted in the AUTHORS file
+
+    This file is part of aziomq
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+#ifndef AZIOMQ_IO_PIPE_HPP_
+#define AZIOMQ_IO_PIPE_HPP_
+
+#include "socket.hpp"
+#include "option.hpp"
+
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/signal_set.hpp>
+
+#include <string>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <functional>
+
+namespace aziomq {
+namespace thread {
+    using is_alive = opt::peer::is_alive;
+    using detached = opt::peer::detached;
+    using last_error = opt::peer::last_error;
+
+    /** \brief create a thread bound to one end of a pair of inproc sockets
+     *  \param peer io_service to associate the peer (caller) end of the pipe
+     *  \param f Function accepting a socket as it's first parameter and a
+     *           number of additional args
+     *  \returns peer socket
+     *
+     *  \remark The newly created thread will be a std::thread, and will receive the
+     *  'server' end of the pipe as it's first argument.  This thread will be
+     *  attached to the lifetime of the returned socket and will run until it is destroyed.
+     *
+     *  \remark Each forked thread has an associated io_service and the supplied socket
+     *  will be created on this io_service. The thread function may access this by calling
+     *  get_io_service() on the supplied socket.
+     *
+     *  \remark The associated io_service is configured to stop the spawned thread on
+     *  SIG_KILL and SIG_TERM.
+     *
+     *  \remark Termination:
+     *      "well behaved" threads should ultimately call run() on the io_service. This allows
+     *      the 'client' end of the socket's lifetime to cleanly signal termination of the thread.
+     *      If for some reason, this is not possible, the caller should set the 'detached' option
+     *      on the 'client' socket. This detaches the associated thread from the client socket
+     *      so that it will not be joined at destuction time. It is then up to the caller to
+     *      work out the termination signal for the background thread; for instance by sending a
+     *      termination message.
+     *
+     *      Also note, the default signal handling for the background thread is desinged to call
+     *      stop() on the associated io_service, so not calling run() in your handler means you
+     *      are responsible for catching these signals in some other way.
+     *
+     *  \remark This is similar in concept to the CZMQ zthread_fork API, except that lifetime is
+     *  controled by the returned socket, not a separate zctx_t instance.
+     */
+    constexpr struct forked_thread {
+        template<typename Function, typename...Args>
+        socket operator()(boost::asio::io_service & peer, Function && f, Args&&... args) const {
+            return make_pipe(peer, std::bind(std::forward<Function>(f),
+                                             std::placeholders::_1,
+                                             std::forward<Args>(args)...));
+        }
+
+    private:
+        using service_type = socket::service_type;
+        struct concept 
+            : std::enable_shared_from_this<concept> {
+
+            std::string uri_;
+            boost::asio::signal_set signals_;
+            boost::asio::io_service ios_;
+            socket s_;
+
+            std::thread t_;
+
+            using lock_t = std::unique_lock<std::mutex>;
+            mutable lock_t::mutex_type mtx_;
+            mutable std::condition_variable cv_;
+
+            // synchronized state
+            bool ready_;
+            bool stopped_;
+            std::exception_ptr last_error_;
+
+            concept()
+                : uri_(get_uri())
+                , signals_(ios_, SIGINT, SIGTERM)
+                , s_(ios_, ZMQ_PAIR)
+                , ready_(false)
+                , stopped_(true)
+            {
+                s_.bind(uri_);
+            }
+
+            virtual ~concept() {
+                try { stop(); } catch (...) { }
+            }
+
+            bool joinable() const { return t_.joinable(); }
+            void stop() {
+                if (joinable()) {
+                    ios_.stop();
+                    t_.join();
+                }
+            }
+
+            void stopped() {
+                lock_t lock(mtx_);
+                stopped_ = true;
+            }
+
+            bool is_stopped() {
+                lock_t lock(mtx_);
+                return stopped_;
+            }
+
+            void ready() {
+                {
+                    lock_t lock(mtx_);
+                    ready_ = true;
+                }
+                cv_.notify_all();
+            }
+
+            void detach() {
+                if (!joinable()) return; // already detached
+
+                lock_t lock(mtx_);
+                cv_.wait(lock, [this] { return ready_; });
+                t_.detach();
+            }
+
+            socket peer_socket(boost::asio::io_service & peer) {
+                auto res = socket(peer, ZMQ_PAIR);
+                res.connect(uri_);
+                return res;
+            }
+
+            virtual void run(socket) = 0;
+
+            void set_last_error(std::exception_ptr last_error) {
+                lock_t lock(mtx_);
+                last_error_ = last_error;
+            }
+
+            std::exception_ptr last_error() const {
+                lock_t lock(mtx_);
+                return last_error_;
+            }
+
+            void run() {
+                signals_.async_wait([this](const boost::system::error_code &, int) {
+                    ios_.stop();
+                });
+
+                auto p = shared_from_this();
+                t_ = std::thread([p] {
+                    p->ready();
+                    try {
+                        p->run(std::move(p->s_));
+                    } catch (...) {
+                        p->set_last_error(std::current_exception());
+                    }
+                    p->stopped();
+                });
+            }
+
+            static std::string get_uri();
+        };
+        using ptr = std::shared_ptr<concept>;
+        using weak_ptr = std::weak_ptr<concept>;
+
+        template<typename T>
+        struct model : concept {
+            T data_;
+
+            model(T data) : data_(std::move(data)) { }
+
+            void run(socket s) { data_(std::move(s)); }
+        };
+
+        struct handler {
+            ptr p_;
+
+            handler(weak_ptr p) : p_(std::move(p)) { }
+
+            handler(handler && rhs) = default;
+            handler & operator=(handler && rhs) = default;
+
+            void on_install() { p_->run(); }
+
+            boost::system::error_code set_option(service_type::opt_concept const& opt,
+                                                 boost::system::error_code & ec) {
+                switch (opt.name()) {
+                    case is_alive::static_name::value :
+                        ec = make_error_code(boost::system::errc::no_protocol_option);
+                        break;
+                    case detached::static_name::value :
+                        {
+                            auto v = reinterpret_cast<detached::value_t const*>(opt.data());
+                            if (*v) p_->detach();
+                        }
+                        break;
+                    case last_error::static_name::value :
+                        ec = make_error_code(boost::system::errc::no_protocol_option);
+                        break;
+                    default: 
+                        ec = make_error_code(boost::system::errc::not_supported);
+                        break;
+                }
+                return ec;
+            }
+
+            boost::system::error_code get_option(service_type::opt_concept & opt,
+                                                 boost::system::error_code & ec) {
+                switch (opt.name()) {
+                    case is_alive::static_name::value :
+                        {
+                            auto v = reinterpret_cast<is_alive::value_t*>(opt.data());
+                            *v = boost::logic::tribool(p_->is_stopped());
+                        }
+                        break;
+                    case detached::static_name::value :
+                        {
+                            auto v = reinterpret_cast<detached::value_t*>(opt.data());
+                            *v = p_->joinable();
+                        }
+                        break;
+                    case last_error::static_name::value :
+                        {
+                            auto v = reinterpret_cast<last_error::value_t*>(opt.data());
+                            *v = p_->last_error();
+                        }
+                        break;
+                    default:
+                      ec = make_error_code(boost::system::errc::not_supported);
+                      break;
+                }
+                return ec; 
+            }
+        };
+
+        template<typename T>
+        static socket make_pipe(boost::asio::io_service & peer, T&& data) {
+            auto p = std::make_shared<model<T>>(std::forward<T>(data));
+            auto res = p->peer_socket(peer);
+            res.associate_handler(handler(std::move(p)));
+            return res;
+        }
+    } fork { };
+} // namespace pipe
+} // namespace aziomq
+#endif // AZIOMQ_IO_PIPE_HPP_
+

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(aziomq SHARED io_service.cpp error.cpp)
+add_library(aziomq SHARED io_service.cpp error.cpp thread.cpp)
 
 target_link_libraries(aziomq ${Boost_LIBRARIES}
                              ${ZeroMQ_LIBRARIES})

--- a/src/lib/thread.cpp
+++ b/src/lib/thread.cpp
@@ -1,0 +1,21 @@
+/*
+    Copyright (c) 2013-2014 Contributors as noted in the AUTHORS file
+
+    This file is part of aziomq
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include "../aziomq/thread.hpp"
+
+#include <boost/format.hpp>
+
+namespace aziomq {
+namespace thread {
+
+std::string forked_thread::concept::get_uri() {
+    static unsigned long id = 0;
+    return boost::str(boost::format("inproc://aziomq-pipe-%1%") % ++id);
+}
+} // namespace pipe
+} // namespace aziomq

--- a/src/test/thread_tests.hpp
+++ b/src/test/thread_tests.hpp
@@ -1,0 +1,76 @@
+/*
+    Copyright (c) 2013-2014 Contributors as noted in the AUTHORS file
+
+    This file is part of aziomq
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+#ifndef __AZIOMQ_TEST_THREAD_HPP__
+#define __AZIOMQ_TEST_THREAD_HPP__
+#include "logger.hpp"
+#include "common.hpp"
+
+#include "../aziomq/error.hpp"
+#include "../aziomq/io_service.hpp"
+#include "../aziomq/option.hpp"
+#include "../aziomq/socket.hpp"
+#include "../aziomq/thread.hpp"
+
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/buffer.hpp>
+
+#include <array>
+#include <string>
+#include <exception>
+#include <mutex>
+#include <condition_variable>
+
+namespace thread_tests {
+namespace detail {
+    std::exception_ptr check_res(const std::string & msg, const std::string & expected) {
+        if (msg != expected) {
+            std::ostringstream stm;
+            stm << "Expecting " << expected << ", got " << msg;
+            return std::make_exception_ptr(std::runtime_error(stm.str()));
+        }
+        return std::exception_ptr();
+    }
+} // namespace detail
+
+void apply() {
+    std::string test_str("Testing");
+    boost::asio::io_service ios;
+    using lock_t = std::unique_lock<std::mutex>;
+    lock_t::mutex_type mtx;
+    std::condition_variable cv;
+    bool finished = false;
+
+    {
+        auto s = aziomq::thread::fork(ios, [&](aziomq::socket p, std::string msg) {
+            p.send(boost::asio::buffer(msg));
+            auto& ios = p.get_io_service();
+            ios.run();
+            {
+                lock_t lk(mtx);
+                finished = true;
+            }
+            cv.notify_one();
+        }, test_str);
+
+        std::array<char, 1025> buf;
+        auto bytes_transferred = s.receive(boost::asio::buffer(buf));
+        auto res = detail::check_res(std::string(buf.data(), bytes_transferred), test_str);
+        if (res != std::exception_ptr())
+            std::rethrow_exception(res);
+    }
+
+    {
+        lock_t lk(mtx);
+        cv.wait(lk, [&] { return finished; });
+    }
+}
+
+} // namespace thread_tests
+#endif // __AZIOMQ_TEST_THREAD_HPP__
+


### PR DESCRIPTION
Creates a background thread with an inproc socket pair connected between the caller of thread::fork and the handler supplied to thread::fork(), which is run in a separate thread.
